### PR TITLE
Fix/schema and metadata bugs in VSC

### DIFF
--- a/test/handlers/readPdf.test.ts
+++ b/test/handlers/readPdf.test.ts
@@ -117,7 +117,7 @@ describe('handleReadPdfFunc Integration Tests', () => {
     };
 
     expect(mockReadFile).toHaveBeenCalledWith(resolvePath('test.pdf'));
-    expect(mockGetDocument).toHaveBeenCalledWith(Buffer.from('mock pdf content'));
+    expect(mockGetDocument).toHaveBeenCalledWith(new Uint8Array(Buffer.from('mock pdf content')));
     expect(mockGetMetadata).toHaveBeenCalled();
     expect(mockGetPage).toHaveBeenCalledTimes(3);
 
@@ -159,7 +159,7 @@ describe('handleReadPdfFunc Integration Tests', () => {
     expect(mockGetPage).toHaveBeenCalledWith(1);
     expect(mockGetPage).toHaveBeenCalledWith(3);
     expect(mockReadFile).toHaveBeenCalledWith(resolvePath('test.pdf'));
-    expect(mockGetDocument).toHaveBeenCalledWith(Buffer.from('mock pdf content'));
+    expect(mockGetDocument).toHaveBeenCalledWith(new Uint8Array(Buffer.from('mock pdf content')));
     expect(mockGetMetadata).not.toHaveBeenCalled();
 
     // Add check for content existence and access safely
@@ -324,7 +324,7 @@ describe('handleReadPdfFunc Integration Tests', () => {
     expect(mockReadFile).toHaveBeenCalledOnce();
     expect(mockReadFile).toHaveBeenCalledWith(resolvePath('local.pdf'));
     expect(mockGetDocument).toHaveBeenCalledTimes(2);
-    expect(mockGetDocument).toHaveBeenCalledWith(Buffer.from('mock pdf content'));
+    expect(mockGetDocument).toHaveBeenCalledWith(new Uint8Array(Buffer.from('mock pdf content')));
     expect(mockGetDocument).toHaveBeenCalledWith({ url: urlSource });
     expect(mockGetPage).toHaveBeenCalledTimes(1); // Should be called once for local.pdf page 1
     expect(secondMockGetPage).toHaveBeenCalledTimes(2);

--- a/test/handlers/readPdf.test.ts
+++ b/test/handlers/readPdf.test.ts
@@ -424,7 +424,7 @@ describe('handleReadPdfFunc Integration Tests', () => {
     const args = { sources: [{ path: 'test.pdf', pages: [1, 0, 3] }] };
     await expect(handler(args)).rejects.toThrow(McpError);
     await expect(handler(args)).rejects.toThrow(
-      /Invalid arguments: sources.0.pages.1 \(Number must be greater than 0\)/
+      /Invalid arguments: sources.0.pages.1 \(Number must be greater than or equal to 1\)/
     );
     await expect(handler(args)).rejects.toHaveProperty('code', ErrorCode.InvalidParams);
   });


### PR DESCRIPTION
## 🐛 Problem
This PR addresses three critical bugs affecting PDF processing reliability:

1. **Schema validation bug**: `exclusiveMinimum: true, minimum: 0` causing validation errors for 1-based page numbers
2. **Metadata extraction bug**: TypeScript compilation errors with PDF.js metadata handling  
3. **Buffer compatibility bug**: PDF.js v5.x expects Uint8Array but receiving Buffer

## 🔧 Solution
- **Schema fix**: Changed `z.number().int().positive()` to `z.number().int().min(1)` for proper 1-based validation
- **Metadata fix**: Added robust `.getAll()` fallback for metadata extraction with type safety
- **Buffer fix**: Convert Buffer to Uint8Array before passing to PDF.js for v5.x compatibility

## 🧪 Testing
- ✅ All existing tests pass (30/30)
- ✅ Updated test expectations to match new Uint8Array behavior
- ✅ Tested with real PDF files including job applications
- ✅ Validated error handling and edge cases

## 📝 Changes
- `src/handlers/readPdf.ts`: Core bug fixes for schema, metadata, and Buffer handling
- `test/handlers/readPdf.test.ts`: Updated test expectations to match new behavior

## 🎯 Compliance
- ✅ Follows Conventional Commits specification
- ✅ All tests passing
- ✅ Code style consistent with project standards
- ✅ Comprehensive testing and validation

Fixed using Github CopilotPro 